### PR TITLE
Catch base exception instead of ZRay\Exception

### DIFF
--- a/zray.php
+++ b/zray.php
@@ -59,7 +59,7 @@ class Symfony {
 			$refclass = new \ReflectionClass($controller);
 			$filename = $refclass->getFileName();
 			$lineno = $refclass->getStartLine();
-		} catch (Exception $e) {
+		} catch (\Exception $e) {
 			$filename = $lineno = '';
 		}
 		$storage['request'][] = array(


### PR DESCRIPTION
Without this, there would still be an exception thrown when the `new \ReflectionClass($controller);` fails.

![screen shot 2014-12-04 at 14 02 04](https://cloud.githubusercontent.com/assets/1918518/5298592/36c4a256-7bbe-11e4-80cf-8de5d2ef0f00.png)
